### PR TITLE
fix: CI link checker workflow (automated bug)

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,22 +3,23 @@ name: Links Checker
 on:
   workflow_dispatch:
   schedule:
-      - cron: "0 0 1,15 * *" # twice a month
+    - cron: "0 0 1,15 * *" # twice a month
 
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - name: Link Checker
+      - name: Run Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1.8.0
 
-      - name: Create Issue From File
-        if: env.lychee_exit_code != 0
+      - name: Create Issue for Broken Links
+        if: ${{ failure() }}
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: Link Checker Report
-          content-filepath: ./lychee/out.md
-          labels: report, automated issue, good first issue
+          title: 'Bug: Found Broken Link (help wanted)'
+          content-filepath: './lychee/out.md'
+          labels: 'report, automated issue, good first issue'


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #173 
<!-- Be noted that $XXX is the issue ID -->

## What is the purpose of the change

<!-- Add a description of the overall background and high level changes that this PR introduces -->

This pull request improves the ci `link-checker.yml` 
- Adjusted the conditional statement  `if: env.lychee_exit_code != 0`  to  `if: env.lychee_exit_code != 0` which is more direct way of checking if link check action failed.
- Enclosed label values in single quotes
- Added checkout code step and refactored the code.


